### PR TITLE
#!削除で一部siteのURLがnot foundを指すようになる件について...

### DIFF
--- a/xpi/chrome/content/library/31_Tombloo.Service.extractors.js
+++ b/xpi/chrome/content/library/31_Tombloo.Service.extractors.js
@@ -1635,7 +1635,9 @@ update(Tombloo.Service.extractors, {
 		var canonical = $x('//link[@rel="canonical"]/@href', doc);
 		if(canonical && !new RegExp(getPref('ignoreCanonical')).test(ctx.href))
 			ctx.href = resolveRelativePath(canonical, ctx.href);
-		ctx.href = ctx.href.replace(/\/#!\//, '/');
+		
+		if(this['Quote - Twitter'].check(ctx))
+			ctx.href = ctx.href.replace(/\/#!\//, '/');
 		
 		return withWindow(ctx.window, function(){
 			return maybeDeferred(ext.extract(ctx)).addCallback(function(ps){


### PR DESCRIPTION
https://plus.google.com/111301234346259872912/posts/XGfJwi1yX3D

という話になりまして, このような変更を加えてみたのですがどうでしょうかー?
issueの背景自体をあまりわかっていなくて, shebangのremoveの処理についてTwitter以外で何か理由がありましたら申し訳ないです...
