### PR TITLE
Quick patch for Firefox 18.0

### DIFF
--- a/xpi/chrome/content/library/01_utility.js
+++ b/xpi/chrome/content/library/01_utility.js
@@ -250,7 +250,7 @@ function download(sourceURL, targetFile, useManger){
 		p.PERSIST_FLAGS_FROM_CACHE |
 		p.PERSIST_FLAGS_REPLACE_EXISTING_FILES |
 		p.PERSIST_FLAGS_AUTODETECT_APPLY_CONVERSION;
-	p.saveURI(sourceURI, null, null, null, null, targetURI);
+	p.saveURI(sourceURI, null, null, null, null, targetURI, null);
 	
 	return d;
 }


### PR DESCRIPTION
nsIWebBrowserPersist.saveURI でエラーが出ているらしく、
cache や capture、パッチのインストールが出来なくなっていました。
正確には調べてませんが、ここらへんが問題のようです。

API の仕様が変わったのでしょうか。引数が一つ増えてます。
https://developer.mozilla.org/en-US/docs/XPCOM_Interface_Reference/nsIWebBrowserPersist#saveURI()
