### PR TITLE
Show Images in QuickPostForm when JavaScript is disabled

### DIFF
--- a/xpi/chrome/content/library/01_utility.js
+++ b/xpi/chrome/content/library/01_utility.js
@@ -2117,17 +2117,17 @@ function loadImage(src){
 		img.src = src;
 	}
 	
-	img.onload = function(){
+	img.addEventListener('load', function(){
 		try{
 			d.callback(img);
 		}catch(e){
 			// ロードが複数回呼び出されて発生するエラーを抑止する
 		}
-	};
+	}, false);
 	
-	img.onerror = function(){
+	img.addEventListener('error', function(){
 		d.errback(img);
-	};
+	}, false);
 	
 	return d;
 }


### PR DESCRIPTION
JavaScriptが無効になっている時に、QuickPostFormで各サービスのアイコンや、Photoポスト時の画像が表示されない(投稿自体はできる)問題を修正しています。

![screenshot](https://f.cloud.github.com/assets/69238/148545/771ba87e-7506-11e2-9729-55b5b2af61eb.PNG)

不具合及びこの変更の動作は、Windows 7 Home Premium SP1 64bit上のFirefox 18.0.2、拡張のバージョンは0.4.34という環境で確認しています。
