### PR TITLE
Remove E4X code for Firefox 20+ #53

### DIFF
--- a/xpi/chrome/content/library/01_utility.js
+++ b/xpi/chrome/content/library/01_utility.js
@@ -2487,7 +2487,7 @@ AbstractSessionService = {
 }
 
 function commentToText(commentFunc) {
-	return (commentFunc).toString().replace(/^.*?\r?\n/,'').replace(/\r?\n.*?$/,'');
+	return commentFunc.toString().replace(/^.*?\r?\n/, '').replace(/\r?\n.*?$/, '');
 }
 
 function getTextContent(node) {

--- a/xpi/chrome/content/library/01_utility.js
+++ b/xpi/chrome/content/library/01_utility.js
@@ -1815,12 +1815,7 @@ function convertToHTMLDocument(html, doc) {
 	return doc
 }
 
-function convertToXML(text){
-	return new XML(text.replace(/<\?.*\?>/gm,'').replace(/<!.*?>/gm, '').replace(/xmlns=["'].*?["']/g,''));
-}
-
 function convertToXULElement(str){
-	str = str.toXMLString? str.toXMLString() : str;
 	var xul = (
 		'<box xmlns="'+XUL_NS+'" >'+
 			str +
@@ -2276,12 +2271,12 @@ function selectRegion(doc){
 	doc.documentElement.style.cursor = 'crosshair';
 	
 	var style = doc.createElement('style');
-	style.innerHTML = <><![CDATA[
+	style.innerHTML = commentToText(function(){/*
 		* {
 			cursor: crosshair !important;
 			-moz-user-select: none;
 		}
-	]]></>.toString();
+	*/});
 	doc.body.appendChild(style);
 	
 	var region, p, d, moving, square;
@@ -2319,14 +2314,14 @@ function selectRegion(doc){
 		
 		p = mouse(e);
 		region = doc.createElement('div');
-		region.setAttribute('style', <>
-			background : #888;
-			opacity    : 0.5;
-			position   : fixed;
-			z-index    : 999999999;
-			top        : {p.y}px;
-			left       : {p.x}px;
-		</>.toString());
+		region.setAttribute('style', [
+			'background : #888;',
+			'opacity    : 0.5;',
+			'position   : fixed;',
+			'z-index    : 999999999;',
+			'top        : ' + p.y + 'px;',
+			'left       : ' + p.x + 'px;'
+		].join('\n'));
 		doc.body.appendChild(region);
 		
 		doc.addEventListener('mousemove', onMouseMove, true);
@@ -2407,13 +2402,13 @@ function flashView(doc){
 	var d = new Deferred();
 	var doc = doc || currentDocument();
 	var flash = doc.createElement('div');
-	flash.setAttribute('style', <>
+	flash.setAttribute('style', commentToText(function(){/*
 		background : #EEE;
 		position   : fixed;
 		z-index    : 999999999;
 		top        : 0;
 		left       : 0;
-	</>.toString());
+	*/}));
 	setElementDimensions(flash, getViewDimensions());
 	doc.body.appendChild(flash);
 	fade(flash, {
@@ -2489,4 +2484,12 @@ AbstractSessionService = {
 			});
 		}
 	},
+}
+
+function commentToText(commentFunc) {
+	return (commentFunc).toString().replace(/^.*?\r?\n/,'').replace(/\r?\n.*?$/,'');
+}
+
+function getTextContent(node) {
+	return node ? node.textContent : '';
 }

--- a/xpi/chrome/content/library/10_Database.js
+++ b/xpi/chrome/content/library/10_Database.js
@@ -402,9 +402,7 @@ function Entity(def){
 		},
 		
 		deinitialize : function(){
-			return Model.db.execute(<>
-				DROP TABLE {def.name} 
-			</>);
+			return Model.db.execute('DROP TABLE ' + def.name);
 		},
 		
 		insert : function(model){
@@ -418,31 +416,29 @@ function Entity(def){
 		},
 		
 		deleteById : function(id){
-			return Model.db.execute(<>
-				DELETE FROM {def.name} 
-				WHERE
-					id = :id
-			</>, id);
+			return Model.db.execute([
+				'DELETE FROM ' + def.name + ' ',
+				'WHERE',
+				'	id = :id'
+			].join('\n'), id);
 		},
 		
 		deleteAll : function(){
-			return Model.db.execute(<>
-				DELETE FROM {def.name} 
-			</>);
+			return Model.db.execute('DELETE FROM ' + def.name);
 		},
 		
 		countAll : function(){
-			return Model.db.execute(<>
-				SELECT count(*) AS count
-				FROM {def.name} 
-			</>)[0].count;
+			return Model.db.execute([
+				'SELECT count(*) AS count ',
+				'FROM ' + def.name
+			].join('\n'))[0].count;
 		},
 		
 		findAll : function(){
-			return this.find(<>
-				SELECT * 
-				FROM {def.name} 
-			</>);
+			return this.find([
+				'SELECT * ',
+				'FROM ' + def.name
+			].join('\n'));
 		},
 		
 		rowToObject : function(obj){
@@ -473,18 +469,18 @@ function Entity(def){
 				
 				switch(type){
 				case 'find':
-					sql = Entity.compactSQL(<>
-						SELECT * 
-						FROM {def.name} 
-						{Entity.createWhereClause(fields)} 
-					</>)
+					sql = Entity.compactSQL([
+						'SELECT * ',
+						'FROM ' + def.name + ' ',
+						Entity.createWhereClause(fields)
+					].join('\n'))
 					break;
 				case 'count':
-					sql = Entity.compactSQL(<>
-						SELECT count(id) AS count
-						FROM {def.name} 
-						{Entity.createWhereClause(fields)} 
-					</>)
+					sql = Entity.compactSQL([
+						'SELECT count(id) AS count',
+						'FROM ' + def.name + ' ',
+						Entity.createWhereClause(fields)
+					].join('\n'))
 					break;
 				}
 				
@@ -506,10 +502,10 @@ function Entity(def){
 
 extend(Entity, {
 	createWhereClause : function(fields){
-		return Entity.compactSQL(<>
-			WHERE
-				{fields.map(function(p){return p + '=:' + p}).join(' AND ')} 
-		</>);
+		return Entity.compactSQL([
+			'WHERE',
+			'	' + fields.map(function(p){return p + '=:' + p}).join(' AND ')
+		].join('\n'));
 	},
 	
 	createInitializeSQL : function(def){
@@ -517,11 +513,11 @@ extend(Entity, {
 		for(var p in def.fields)
 			fields.push(p + ' ' + def.fields[p].replace('TIMESTAMP', 'INTEGER').replace('LIST', 'TEXT'));
 		
-		return Entity.compactSQL(<>
-			CREATE TABLE IF NOT EXISTS {def.name} (
-				{fields.join(', ')} 
-			)
-		</>);
+		return Entity.compactSQL([
+			'CREATE TABLE IF NOT EXISTS ' + def.name + ' (',
+			'	' + fields.join(', ') + ' ',
+			')'
+		].join('\n'));
 	},
 	
 	createInsertSQL : function(def){
@@ -529,13 +525,13 @@ extend(Entity, {
 		var params = fields.map(function(p){
 			return ':' + p
 		});
-		return Entity.compactSQL(<>
-			INSERT INTO {def.name} (
-				{fields.join(', ')}
-			) VALUES (
-				{params.join(', ')}
-			)
-		</>);
+		return Entity.compactSQL([
+			'INSERT INTO ' + def.name + ' (',
+			'	' + fields.join(', '),
+			') VALUES (',
+			'	' + params.join(', '),
+			')'
+		].join('\n'));
 	},
 	
 	createUpdateSQL : function(def){
@@ -545,13 +541,13 @@ extend(Entity, {
 				return p + '=:' + p;
 			}).join(', ');
 		
-		return Entity.compactSQL(<>
-			UPDATE {def.name} 
-			SET 
-				{fields} 
-			WHERE 
-				id = :id
-		</>);
+		return Entity.compactSQL([
+			'UPDATE ' + def.name + ' ',
+			'SET ',
+			'	' + fields + ' ',
+			'WHERE ',
+			'	id = :id'
+		].join('\n'));
 	},
 	
 	/**

--- a/xpi/chrome/content/library/20_Tombloo.js
+++ b/xpi/chrome/content/library/20_Tombloo.js
@@ -54,7 +54,7 @@ var Tombloo = {
 			
 			Tag.initialize();
 			
-			db.execute(<>
+			db.execute(commentToText(function(){/*
 				CREATE TABLE temp (
 					id        INTEGER PRIMARY KEY, 
 					user      TEXT, 
@@ -77,7 +77,7 @@ var Tombloo = {
 					photos;
 				DROP TABLE photos;
 				ALTER TABLE temp RENAME TO photos;
-			</>);
+			*/}));
 			
 			db.version = SCHEMA_VERSION;
 			db.vacuum();
@@ -300,7 +300,7 @@ extend(Tombloo.Post, {
 	
 	initialize : function(){
 		try{
-			return this.db.execute(<>
+			return this.db.execute(commentToText(function(){/*
 				CREATE VIEW posts AS 
 				SELECT "regular" AS type, id, user, date, 
 					title, 
@@ -349,13 +349,11 @@ extend(Tombloo.Post, {
 					"" AS player, 
 					"" AS imageId 
 				FROM quotes 
-			</>);
+			*/}));
 		} catch(e if e instanceof Database.AlreadyExistsException){}
 	},
 	
 	deinitialize : function(){
-		return this.db.execute(<>
-			DROP VIEW posts 
-		</>);
+		return this.db.execute('DROP VIEW posts');
 	},
 });

--- a/xpi/chrome/content/library/20_model.js
+++ b/xpi/chrome/content/library/20_model.js
@@ -223,10 +223,11 @@ models.register(update({
 				sendContent : ps,
 			});
 		}).addCallback(function(res){
-			res = convertToXML(res.responseText);
-			if(res.@stat!='ok'){
-				var err = new Error(''+res.err.@msg)
-				err.code = res.err.@code;
+			res = convertToDOM(res.responseText);
+			if(res.querySelector('[stat]').getAttribute('stat')!='ok'){
+				var errElem = res.querySelector('err');
+				var err = new Error(errElem.getAttribute('msg'))
+				err.code = errElem.getAttribute('code');
 				
 				throw err;
 			}
@@ -311,7 +312,7 @@ models.register(update({
 		return this.callAuthMethod(update({
 			method   : 'flickr.photos.upload',
 		}, ps)).addCallback(function(res){
-			return ''+res.photoid;
+			return getTextContent(res.querySelector('photoid'));
 		});
 	},
 	
@@ -1976,8 +1977,8 @@ models.register({
 			},
 		}).addCallback(function(res){
 			return map(function(s){
-				return ''+s.@title || ''+s;
-			}, convertToXML(res.responseText).li.span);
+				return s.getAttribute('title') || s.textContent;
+			}, convertToDOM(res.responseText).querySelectorAll('li > span'));
 		});
 	},
 });
@@ -2099,11 +2100,11 @@ models.register({
 				duplicated : false,
 				tags : reduce(function(memo, tag){
 					memo.push({
-						name      : tag.@tag,
-						frequency : tag.@count,
+						name      : tag.getAttribute('tag'),
+						frequency : tag.getAttribute('count'),
 					});
 					return memo;
-				}, convertToXML(res.responseText).tag, []),
+				}, convertToDOM(res.responseText).querySelectorAll('tag'), []),
 			};
 		});
 	},
@@ -2357,26 +2358,26 @@ models.register( {
 		},
 		
 		photo : function(ps, title){
-			return ''+<>
-				<blockquote cite={ps.pageUrl} title={title}>
-					<img src={ps.itemUrl} />
-				</blockquote>
-				{ps.description}
-			</>;
+			return [
+				'<blockquote cite=' + ps.pageUrl + ' title=' + title + '>',
+				'	<img src=' + ps.itemUrl + ' />',
+				'</blockquote>',
+				ps.description
+			].join('\n');
 		},
 		
 		link : function(ps, title){
-			return ''+<>
-				<a href={ps.pageUrl} title={title}>{ps.page}</a>
-				{ps.description}
-			</>;
+			return [
+				'<a href=' + ps.pageUrl + ' title=' + title + '>' + ps.page + '</a>',
+				ps.description
+			].join('\n');
 		},
 		
 		quote : function(ps, title){
-			return ''+<>
-				<blockquote cite={ps.pageUrl} title={title}>{ps.body}</blockquote>
-				{ps.description}
-			</>;
+			return [
+				'<blockquote cite=' + ps.pageUrl + ' title=' + title + '>' + ps.body + '</blockquote>',
+				ps.description
+			].join('\n');
 		},
 	},
 	

--- a/xpi/chrome/content/library/40_ui.js
+++ b/xpi/chrome/content/library/40_ui.js
@@ -166,7 +166,7 @@ forEach({
 		
 		// FIXME: xul:popup要素の使用を検討
 		var tip = doc.createElement('div');
-		tip.setAttribute('style', ''+<>
+		tip.setAttribute('style', commentToText(function(){/*
 			font-family        : 'Arial Black', Arial, sans-serif;
 			font-size          : 12px;
 			
@@ -184,7 +184,7 @@ forEach({
 			border             : 4px solid #EEE;
 			padding-left       : 20px;
 			padding-right      : 2px;
-		</>);
+		*/}));
 		tip.textContent = ext.name;
 		convertToDataURL(ext.ICON).addCallback(function(dataUrl){
 			tip.style.backgroundImage = 'url(' + dataUrl + ')';

--- a/xpi/components/tombloo.js
+++ b/xpi/components/tombloo.js
@@ -40,7 +40,7 @@ function setupEnvironment(global){
 	// 変数/定数はhiddenDOMWindowのものを直接使う
 	[
 		'navigator document window screen',
-		'XMLHttpRequest XPathResult Node Element KeyEvent Event DOMParser XSLTProcessor XML XMLSerializer NodeFilter',
+		'XMLHttpRequest XPathResult Node Element KeyEvent Event DOMParser XSLTProcessor XMLSerializer NodeFilter',
 	].join(' ').split(' ').forEach(function(p){
 		global[p] = win[p];
 	});


### PR DESCRIPTION
Firefox 20以降で実施されるE4Xの無効化と削除に対応する為、E4Xが使用されている処理の削除、及び互換性のある処理への置き換えを行なっています。

> E4X is obsolete. It has been disabled by default for webpages (content) in Firefox 17, disabled by default for chrome in Firefox 20, and will be removed in Firefox 21.

[E4X | MDN](https://developer.mozilla.org/en-US/docs/E4X)

Firefox 20ではabout:configに「javascript.options.xml.chrome」、「javascript.options.xml.content」は存在するのですが、これらを有効にしてもTomblooは動作しませんでした。Firefox 21以降ではこれらは存在しません。
![screenshot](https://f.cloud.github.com/assets/69238/216976/c4381900-84db-11e2-940f-d6ecc3cabdfa.PNG)

不具合及びこの変更の動作は、Windows 7 Home Premium SP1 64bit上のFirefox Beta 20.0、拡張のバージョンは0.4.34という環境で確認しています。
