### PR TITLE
Fix 2 bugs about Firefox 22+

### DIFF
--- a/xpi/chrome/content/library/40_ui.js
+++ b/xpi/chrome/content/library/40_ui.js
@@ -247,8 +247,8 @@ connect(grobal, 'browser-load', function(e){
 		if(e.eventPhase != Event.AT_TARGET || (context && context.target == cwin.gContextMenu.target))
 			return;
 		
-		var doc = wrappedObject(cwin.gContextMenu.target.ownerDocument);
-		var win = wrappedObject(doc.defaultView);
+		var doc = cwin.gContextMenu.target.ownerDocument;
+		var win = doc.defaultView;
 		try{
 			win.location.host;
 			
@@ -268,7 +268,7 @@ connect(grobal, 'browser-load', function(e){
 			window    : win,
 			title     : doc.title,
 			selection : ''+win.getSelection(),
-			target    : wrappedObject(cwin.gContextMenu.target),
+			target    : cwin.gContextMenu.target,
 			mouse     : {
 				page   : {x : e.pageX, y : e.pageY},
 				screen : {x : e.screenX, y : e.screenY},

--- a/xpi/chrome/content/prefs.xul
+++ b/xpi/chrome/content/prefs.xul
@@ -448,8 +448,13 @@
 			
 			getCellProperties : function(row, {index : col}, props){
 				var val = this.rows[row][col];
-				if(col!=0 && val)
-					props.AppendElement(AtomService.getAtom(val));
+				if (col!=0 && val) {
+					if (props) {
+						props.AppendElement(AtomService.getAtom(val));
+					} else {
+						return AtomService.getAtom(val);
+					}
+				}
 			},
 			
 			getCellText : function(row, {index : col}){


### PR DESCRIPTION
Firefox 22.0以上で発生する2つの不具合を修正しました。
- Firefox 22.0以上で設定ダイアログの「デフォルトのポスト先」でチェックマークが表示されない #57
- Firefox 23.0以上でコンテキストメニューの「Share…」のサブメニューが表示されない

不具合及びこの変更の動作は、Windows 7 Home Premium SP1 64bit上のFirefox Aurora 23.0a2、拡張のバージョンは0.4.36( cb60cd0115196e5ff217309918322d52f7eb2ca1 までの変更を含む)という環境で確認しています。
